### PR TITLE
[#20] Allow albums to fetch Assets along with StaticAssets

### DIFF
--- a/Sources/PhotoKitKit/Asset/StaticAsset.swift
+++ b/Sources/PhotoKitKit/Asset/StaticAsset.swift
@@ -14,7 +14,7 @@ import AppKit
 public typealias UIImage = NSImage
 #endif
 
-public protocol AssetRepresentable: Identifiable {
+public protocol AssetRepresentable: Identifiable, PHFetchableWrapper {
     // Properties
     var phAsset: PHAsset { get }
     init(_ phAsset: PHAsset)
@@ -53,7 +53,7 @@ extension AssetRepresentable {
 
 // MARK: - StaticAsset
 
-public struct StaticAsset: Hashable, PHFetchableWrapper {
+public struct StaticAsset: Hashable {
     public let phAsset: PHAsset
     
     public init(_ phAsset: PHAsset) {

--- a/Sources/PhotoKitKit/PHFetchResults.swift
+++ b/Sources/PhotoKitKit/PHFetchResults.swift
@@ -9,25 +9,33 @@ import Photos
 
 // MARK: - PHFetchableWrapper
 
-public protocol PHFetchableWrapper {
+public protocol PHFetchableWrapper: Hashable {
     associatedtype Wrapped: PHObject
     init(_: Wrapped)
 }
 
 // MARK: - PHFetchResults
 
-public struct PHFetchResults<Wrapper: PHFetchableWrapper>: Hashable {
+public struct PHFetchResults<Wrapper: PHFetchableWrapper>: RandomAccessCollection {
     typealias FetchResults = PHFetchResult<Wrapper.Wrapped>
-    var fetchResults: FetchResults
-    
-    init(_ fetchResults: FetchResults) {
-        self.fetchResults = fetchResults
+    var fetchResults: FetchResults {
+        didSet {
+            cache.clear()
+        }
     }
-}
-
-// MARK: - RandomAccessCollection
-
-extension PHFetchResults: RandomAccessCollection {
+    
+    private var cache: Cache
+    
+    fileprivate class Cache {
+        private var items: [Wrapper?]
+        
+        private init(items: [Wrapper?]) {
+            self.items = items
+        }
+    }
+    
+    // MARK: RandomAccessCollection
+    
     public var startIndex: Int {
         0
     }
@@ -40,9 +48,69 @@ extension PHFetchResults: RandomAccessCollection {
         i + 1
     }
     
+    // There is no point in caching when Wrapper is a struct
+    // (which will be copied on each read anyway) since
+    // PHFetchResult handles its own caching of the PHObjects
+    // themselves. As a result, subscript is defined differently
+    // in extensions depending on if Wrapper is a class or not.
+}
+
+// MARK: - Wrapper is a class
+
+extension PHFetchResults where Wrapper: AnyObject {
+    init(_ fetchResults: FetchResults) {
+        self.fetchResults = fetchResults
+        self.cache = Cache(items: fetchResults.count)
+    }
+    
     public subscript(position: Int) -> Wrapper {
-        // PHFetchResults is a class and I believe it has its own cache, so
-        // I don't need to worry about caching stuff in AssetResults itself
+        cache.item(at: position, defaultValue: fetchResults.object(at: position))
+    }
+}
+
+extension PHFetchResults.Cache where Wrapper: AnyObject {
+    convenience init(items: Int) {
+        self.init(items: [Wrapper?](repeating: nil, count: items))
+    }
+    
+    func item(at index: Int, defaultValue: @autoclosure () -> Wrapper.Wrapped) -> Wrapper {
+        guard items.indices.contains(index) else {
+            // Initialization did not occur properly so the
+            // array is not large enough. Should never happen.
+            return Wrapper(defaultValue())
+        }
+        
+        return items[index] ?? {
+            let item = Wrapper(defaultValue())
+            items[index] = item
+            return item
+        }()
+    }
+    
+    func clear() {
+        items.removeAll(keepingCapacity: true)
+    }
+}
+
+// MARK: - Wrapper is a struct
+
+extension PHFetchResults /* where Wrapper is a struct */ {
+    init(_ fetchResults: FetchResults) {
+        self.fetchResults = fetchResults
+        self.cache = Cache()
+    }
+    
+    public subscript(position: Int) -> Wrapper {
+        // PHFetchResult is a class and has its own cache, so we
+        // don't need to worry about caching stuff ourselves.
         Wrapper(fetchResults.object(at: position))
     }
+}
+
+extension PHFetchResults.Cache /* where Wrapper is a struct */ {
+    convenience init() {
+        self.init(items: [])
+    }
+    
+    func clear() { }
 }

--- a/Sources/PhotoKitKit/PhotoCollection.swift
+++ b/Sources/PhotoKitKit/PhotoCollection.swift
@@ -125,6 +125,14 @@ extension PhotoCollection.Album {
             .allObjects()
             .map(StaticAsset.init)
     }
+    
+    public func fetchDynamicAssets() -> PHFetchResults<Asset> {
+        .init(Self.assetFetcher.fetchAssets(in: phAlbum, options: nil))
+    }
+    
+    public func getDynamicAssets() -> [Asset] {
+        self.getAssets().map(Asset.init)
+    }
 }
 
 // MARK: Folder + Convenience


### PR DESCRIPTION
Implement PHFetchResults caching to allow Wrappers to be classes without getting redundant instances